### PR TITLE
fix short_names -> shortNames

### DIFF
--- a/lib/bonny/controller.ex
+++ b/lib/bonny/controller.ex
@@ -72,7 +72,7 @@ defmodule Bonny.Controller do
           plural: "#{singular}s",
           singular: singular,
           kind: name,
-          short_names: nil
+          shortNames: nil
         }
       end
     end

--- a/lib/bonny/crd.ex
+++ b/lib/bonny/crd.ex
@@ -13,7 +13,7 @@ defmodule Bonny.CRD do
           kind: String.t(),
           singular: String.t(),
           plural: String.t(),
-          short_names: nil | list(String.t()),
+          shortNames: nil | list(String.t()),
           version: String.t()
         }
 

--- a/priv/templates/bonny.gen/controller.ex
+++ b/priv/templates/bonny.gen/controller.ex
@@ -22,7 +22,7 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
     plural: "foos",
     singular: "foo",
     kind: "Foo",
-    short_names: ["f", "fo"]
+    shortNames: ["f", "fo"]
   }
   ```
 
@@ -51,7 +51,7 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
     plural: "<%= plural %>",
     singular: "<%= singular %>",
     kind: "<%= mod_name %>",
-    short_names: []
+    shortNames: []
   }
 
   # @rule {"", ["pods", "configmap"], ["*"]}

--- a/test/bonny/controller_test.exs
+++ b/test/bonny/controller_test.exs
@@ -12,7 +12,7 @@ defmodule Bonny.ControllerTest do
           plural: "whizbangs",
           singular: "whizbang",
           kind: "Whizbang",
-          short_names: nil
+          shortNames: nil
         }
       }
 

--- a/test/bonny/crd_test.exs
+++ b/test/bonny/crd_test.exs
@@ -17,7 +17,7 @@ defmodule Bonny.CRDTest do
         },
         spec: %Bonny.CRD{
           group: "example.com",
-          names: %{kind: "Widget", plural: "widgets", short_names: nil, singular: "widget"},
+          names: %{kind: "Widget", plural: "widgets", shortNames: nil, singular: "widget"},
           scope: "Namespaced",
           version: "v1"
         }

--- a/test/bonny/operator_test.exs
+++ b/test/bonny/operator_test.exs
@@ -70,7 +70,7 @@ defmodule Bonny.OperatorTest do
           names: %{
             kind: "Widget",
             plural: "widgets",
-            short_names: nil,
+            shortNames: nil,
             singular: "widget"
           },
           scope: "Namespaced",
@@ -89,7 +89,7 @@ defmodule Bonny.OperatorTest do
           names: %{
             kind: "Cog",
             plural: "cogs",
-            short_names: nil,
+            shortNames: nil,
             singular: "cog"
           },
           scope: "Namespaced",


### PR DESCRIPTION
problem: 
- currently short names are completely ignored by k8s


solution:
- use camelcase. It looks a bit weird in Elixir, but works
- alternative would be to dynamically adjust casing on all field names in requests / responses and this might introduce own problems. imho: keep it `KISS`