### PR TITLE
Integrates telemetry library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Implemented `:telemetry` library
+- `Bonny.Telemetry.events/0` exposes list of telemetry events
 - `mix bonny.gen.manifest --local` for building manifests w/o a Deployment for
   local testing
 - `cluster_name: :default` config options. Now uses [k8s](https://github.com/coryodaniel/k8s) cluster registration configuration.
@@ -16,13 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Async watcher event dispatch
-- Replaced `HTTPoison` with [k8s](https://github.com/coryodaniel/k8s).
+- Replaced `HTTPoison` with [k8s](https://github.com/coryodaniel/k8s)
 
 ### Removed
 
-- Removed `Bypass` from test suite
-- Removed `Impl.parse_metadata/1`.
-- Removed `kubeconf_file` and `kubeconf_opts` config options
+- Renamed `group_version` -> `api_version`
+- Renamed `Bonny.CRD.plural/0` -> `Bonny.CRD.kind/0`
+- `Bypass` from test suite
+- `Impl.parse_metadata/1`
+- `kubeconf_file` and `kubeconf_opts` config options
 
 ## [0.3.0] - 2019-03-04
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ TODO: Need to support validation / OpenAPI.
 - https://github.com/coryodaniel/bonny/issues/9
 - https://github.com/coryodaniel/bonny/issues/10
 
+## Telemetry
+
+Bonny uses the `telemetry` library to emit event metrics.
+
+Emmited events:
+
+- [:bonny, :watcher, :initialized]
+- [:bonny, :watcher, :started]
+- [:bonny, :watcher, :dispatched]
+
 ## Terminology
 
 _[Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-resources)_:

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,8 @@ if Mix.env() == :test do
 end
 
 if Mix.env() == :dev do
+  config :logger, level: :debug
+
   config :mix_test_watch,
     tasks: [
       "test --cover",

--- a/lib/bonny/application.ex
+++ b/lib/bonny/application.ex
@@ -4,6 +4,8 @@ defmodule Bonny.Application do
   use Application
 
   def start(_type, _args) do
+    Bonny.Telemetry.attach()
+
     children =
       Bonny.Config.controllers()
       |> Enum.map(fn controller ->

--- a/lib/bonny/controller.ex
+++ b/lib/bonny/controller.ex
@@ -7,9 +7,9 @@ defmodule Bonny.Controller do
   Controllers allow for simple `add`, `modify`, and `delete` handling of custom resources in the Kubernetes API.
   """
 
-  @callback add(map()) :: :ok | :error
-  @callback modify(map()) :: :ok | :error
-  @callback delete(map()) :: :ok | :error
+  @callback add(map()) :: :ok | :error | {:error, binary}
+  @callback modify(map()) :: :ok | :error | {:error, binary}
+  @callback delete(map()) :: :ok | :error | {:error, binary}
 
   @doc false
   defmacro __using__(_opts) do

--- a/lib/bonny/crd.ex
+++ b/lib/bonny/crd.ex
@@ -33,28 +33,28 @@ defmodule Bonny.CRD do
             version: nil
 
   @doc """
-  Plural name of CRD
+  CRD Kind or plural name
 
   ## Examples
 
-      iex> Bonny.CRD.plural(%Bonny.CRD{names: %{plural: "greetings"}, scope: :namespaced, group: "test", version: "v1"})
+      iex> Bonny.CRD.kind(%Bonny.CRD{names: %{plural: "greetings"}, scope: :namespaced, group: "test", version: "v1"})
       "greetings"
 
   """
-  @spec plural(Bonny.CRD.t()) :: binary
-  def plural(%Bonny.CRD{names: %{plural: plural}}), do: plural
+  @spec kind(Bonny.CRD.t()) :: binary
+  def kind(%Bonny.CRD{names: %{plural: plural}}), do: plural
 
   @doc """
   Gets group version from CRD spec
 
   ## Examples
 
-      iex> Bonny.CRD.group_version(%Bonny.CRD{group: "hello.example.com", version: "v1", scope: :namespaced, names: %{}})
+      iex> Bonny.CRD.api_version(%Bonny.CRD{group: "hello.example.com", version: "v1", scope: :namespaced, names: %{}})
       "hello.example.com/v1"
 
   """
-  @spec group_version(Bonny.CRD.t()) :: binary
-  def group_version(%Bonny.CRD{group: g, version: v}), do: "#{g}/#{v}"
+  @spec api_version(Bonny.CRD.t()) :: binary
+  def api_version(%Bonny.CRD{group: g, version: v}), do: "#{g}/#{v}"
 
   @doc """
   Generates the map equivalent of the Kubernetes CRD YAML manifest

--- a/lib/bonny/operator.ex
+++ b/lib/bonny/operator.ex
@@ -19,7 +19,7 @@ defmodule Bonny.Operator do
 
   @doc "ClusterRole rules"
   def rules do
-    plural_names = Enum.map(Bonny.Config.controllers(), &Bonny.CRD.plural(&1.crd_spec()))
+    plural_names = Enum.map(Bonny.Config.controllers(), &Bonny.CRD.kind(&1.crd_spec()))
 
     base_rules = [
       %{

--- a/lib/bonny/telemetry.ex
+++ b/lib/bonny/telemetry.ex
@@ -1,0 +1,36 @@
+defmodule Bonny.Telemetry do
+
+  @spec events() :: list(list(atom))
+  def events() do
+    [
+      [:bonny, :test]
+    ]
+  end
+
+  def measure(function) do
+    function
+    |> :timer.tc
+    |> elem(0)
+    |> Kernel./(1_000_000)
+  end
+
+  def test() do
+    latency = measure fn -> :timer.sleep(100) end
+    :telemetry.execute([:bonny, :test], %{latency: latency}, %{controller: "foo"})
+  end
+
+  def attach() do
+    :telemetry.attach_many("log-handler", events(), &Bonny.Telemetry.DebugLogger.handle_event/4, nil)
+  end
+end
+
+defmodule Bonny.Telemetry.DebugLogger do
+  require Logger
+
+  def handle_event(event, measurements, metadata, _config) do
+    Logger.debug(fn ->
+      event_name = Enum.join(event, ":")
+      "[#{event_name}] #{inspect(measurements)} #{inspect(metadata)}"
+    end)
+  end
+end

--- a/lib/bonny/telemetry.ex
+++ b/lib/bonny/telemetry.ex
@@ -1,26 +1,68 @@
 defmodule Bonny.Telemetry do
-
+  @moduledoc """
+  List of telemetry events.
+  """
   @spec events() :: list(list(atom))
   def events() do
     [
-      [:bonny, :test]
+      [:bonny, :watcher, :initialized],
+      [:bonny, :watcher, :started],
+      [:bonny, :watcher, :dispatched]
     ]
   end
 
+  @doc """
+  Emits telemetry.
+
+  **Note:** This method switches the order of `measurements` and `metadata`
+  """
+  @spec emit(atom) :: no_return
+  @spec emit(atom, fun) :: no_return
+  @spec emit(atom, map) :: no_return
+  @spec emit(atom, map, map) :: no_return
+  @spec emit(atom, map, fun) :: no_return
+  @spec emit(list(atom), map, fun) :: no_return
+  def emit(name), do: emit(name, %{}, %{})
+  def emit(name, metadata = %{}), do: emit(name, %{}, metadata)
+  def emit(name, func) when is_function(func), do: emit(name, %{}, func)
+
+  def emit(name, metadata = %{}, func) when is_function(func),
+    do: emit(name, metadata, %{duration: measure(func)})
+
+  def emit(name, metadata = %{}, measurements = %{}) when is_atom(name),
+    do: emit([name], measurements, metadata)
+
+  def emit(names, metadata = %{}, measurements = %{}) when is_list(names),
+    do: :telemetry.execute([:bonny | names], measurements, metadata)
+
+  @doc """
+  Measures a functions execution time in seconds
+
+  ## Examples
+
+      iex> Bonny.Telemetry.measure fn ->
+      ...>   :timer.sleep(1000)
+      ...>   "Hello!"
+      ...> end
+      {1.00426, "Hello!"}
+  """
+  @spec measure(fun) :: {float(), any()}
   def measure(function) do
-    function
-    |> :timer.tc
-    |> elem(0)
-    |> Kernel./(1_000_000)
+    {elapsed, retval} = :timer.tc(function)
+    seconds = elapsed / 1_000_000
+
+    {seconds, retval}
   end
 
-  def test() do
-    latency = measure fn -> :timer.sleep(100) end
-    :telemetry.execute([:bonny, :test], %{latency: latency}, %{controller: "foo"})
-  end
-
+  @spec attach() :: no_return
+  @doc false
   def attach() do
-    :telemetry.attach_many("log-handler", events(), &Bonny.Telemetry.DebugLogger.handle_event/4, nil)
+    :telemetry.attach_many(
+      "debug-logger",
+      events(),
+      &Bonny.Telemetry.DebugLogger.handle_event/4,
+      nil
+    )
   end
 end
 

--- a/lib/bonny/watcher.ex
+++ b/lib/bonny/watcher.ex
@@ -14,7 +14,6 @@ defmodule Bonny.Watcher do
   @impl GenServer
   def init(controller) do
     state = Impl.new(controller)
-    Logger.debug(fn -> "Starting new Bonny.Watcher #{inspect(state)}" end)
     schedule_watcher()
     {:ok, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Bonny.MixProject do
     [
       {:jason, "~> 1.1"},
       {:k8s, "~> 0.2"},
+      {:telemetry, ">=  0.4.0"},
 
       # Dev deps
       {:mix_test_watch, "~> 0.8", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -30,6 +30,7 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "yamerl": {:hex, :yamerl, "0.7.0", "e51dba652dce74c20a88294130b48051ebbbb0be7d76f22de064f0f3ccf0aaf5", [:rebar3], [], "hexpm"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.1.0", "79ec163e0f379dadf4b0e8b5162567dc1feb96c3cfa793105869e2c616ab4342", [:mix], [{:yamerl, "~> 0.7", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm"},

--- a/priv/templates/bonny.gen/controller.ex
+++ b/priv/templates/bonny.gen/controller.ex
@@ -60,7 +60,7 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
   @doc """
   Handles an `ADDED` event
   """
-  @spec add(map()) :: :ok | :error
+  @spec add(map()) :: :ok | :error | {:error, binary}
   @impl Bonny.Controller
   def add(payload) do
     IO.inspect(payload)
@@ -70,7 +70,7 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
   @doc """
   Handles a `MODIFIED` event
   """
-  @spec modify(map()) :: :ok | :error
+  @spec modify(map()) :: :ok | :error | {:error, binary}
   @impl Bonny.Controller
   def modify(payload) do
     IO.inspect(payload)
@@ -80,7 +80,7 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
   @doc """
   Handles a `DELETED` event
   """
-  @spec delete(map()) :: :ok | :error
+  @spec delete(map()) :: :ok | :error | {:error, binary}
   @impl Bonny.Controller
   def delete(payload) do
     IO.inspect(payload)

--- a/test/bonny/watcher/impl_test.exs
+++ b/test/bonny/watcher/impl_test.exs
@@ -2,12 +2,15 @@ defmodule Bonny.Watcher.ImplTest do
   @moduledoc false
   use ExUnit.Case, async: true
   alias Bonny.Watcher.Impl
+  doctest Bonny.Watcher.Impl
 
-  defp chunk(), do: "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"example.com/v1\\\",\\\"kind\\\":\\\"Widget\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"test-widget\\\",\\\"namespace\\\":\\\"default\\\"}}\\n\"},\"clusterName\":\"\",\"creationTimestamp\":\"2018-12-17T06:26:41Z\",\"generation\":1,\"name\":\"test-widget\",\"namespace\":\"default\",\"resourceVersion\":\"705460\",\"selfLink\":\"/apis/example.com/v1/namespaces/default/widgets/test-widget\",\"uid\":\"b7464e30-01c4-11e9-9066-025000000001\"}}}\n"
+  defp chunk(),
+    do:
+      "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"example.com/v1\\\",\\\"kind\\\":\\\"Widget\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"test-widget\\\",\\\"namespace\\\":\\\"default\\\"}}\\n\"},\"clusterName\":\"\",\"creationTimestamp\":\"2018-12-17T06:26:41Z\",\"generation\":1,\"name\":\"test-widget\",\"namespace\":\"default\",\"resourceVersion\":\"705460\",\"selfLink\":\"/apis/example.com/v1/namespaces/default/widgets/test-widget\",\"uid\":\"b7464e30-01c4-11e9-9066-025000000001\"}}}\n"
 
   defmodule Whizbang do
     @moduledoc false
-
+    use Bonny.Controller
     use Agent
 
     def start_link() do
@@ -15,11 +18,11 @@ defmodule Bonny.Watcher.ImplTest do
     end
 
     def get() do
-      Agent.get(__MODULE__, fn(events) -> events end)
+      Agent.get(__MODULE__, fn events -> events end)
     end
 
     def put(event) do
-      Agent.update(__MODULE__, fn(events) -> [event|events] end)
+      Agent.update(__MODULE__, fn events -> [event | events] end)
     end
 
     def add(evt), do: put({:added, evt})
@@ -86,12 +89,12 @@ defmodule Bonny.Watcher.ImplTest do
       {:ok, _} = Whizbang.start_link()
 
       chunk()
-      |> Impl.parse_chunk
+      |> Impl.parse_chunk()
       |> Impl.dispatch(Whizbang)
 
       # Professional.
       :timer.sleep(1000)
-      assert [{:added, event}] = Whizbang.get
+      assert [{:added, event}] = Whizbang.get()
       assert %{"apiVersion" => "example.com/v1"} = event
     end
   end

--- a/test/support/k8s_mock_client.ex
+++ b/test/support/k8s_mock_client.ex
@@ -1,6 +1,6 @@
 defmodule Bonny.K8sMockClient do
-  def list(group_version, kind, path_params) do
-    K8s.Operation.build(:list, group_version, kind, path_params)
+  def list(api_version, kind, path_params) do
+    K8s.Operation.build(:list, api_version, kind, path_params)
   end
 
   def watch(_op, :test, opts) do


### PR DESCRIPTION
Currently emitting three events:

- [:bonny, :watcher, :initialized]
- [:bonny, :watcher, :started]
- [:bonny, :watcher, :dispatched]

`Bonny.Telemetry.events/0` returns the list of events, for use with `attach_many`.

All events contain controller/CRD metadata. `:dispatched` contains a measurement of dispatch time and whether the dispatched function returned successfully.

Closes #33 