### PR TITLE
Support CRD Reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for a reconcile/1 callback
+- `reconcile_every` config option to schedule how often to run
+reconciliation
+- `reconcile_batch_size` to set the size of the HTTP GET limit
+when fetching batches of items to reconcile
 - Added `{:error, binary}` as a return value of Controller lifecycle methods
 - Implemented `:telemetry` library
 - `Bonny.Telemetry.events/0` exposes list of telemetry events
@@ -20,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Async watcher event dispatch
 - Replaced `HTTPoison` with [k8s](https://github.com/coryodaniel/k8s)
+
+### Fixed
+
+- Receiving :DOWN messages no longer crashes Watcher #20
+- Issue with partially received events #43
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ when fetching batches of items to reconcile
 
 ### Fixed
 
-- Receiving :DOWN messages no longer crashes Watcher #20
-- Issue with partially received events #43
+- Receiving :DOWN messages no longer crashes Watcher [#20](https://github.com/coryodaniel/bonny/issues/20)
+- Issue with partially received events [#43](https://github.com/coryodaniel/bonny/issues/43)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ config :bonny,
   # K8s.Cluster to use, defaults to :default
   cluster_name: :default,
 
+  # How often to run the reconciler for all controllers in milliseconds.
+  # Default: 300000ms (5 minutes)
+  reconcile_every: 10 * 60 * 1000,
+
+  # Batch size of HTTP request; maps to the Kubernetes `limit` API parameter.
+  # If `continue` is returned additional HTTP requests will be made to fetch all batches of items
+  # Default: 50
+  reconcile_batch_size: 100
+
   # Set the Kubernetes API group for this operator.
   # This can be overwritten using the @group attribute of a controller
   group: "your-operator.example.com",

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,14 +1,17 @@
 {
   "skip_files": [
-    "test/support/"
+    "test/support/",
+    "lib/mix/bonny.ex",
+    "lib/bonny/telemetry.ex"
   ],
   "default_stop_words": [
+    "Logger",
     "defmodule",
     "defrecord",
+    "defstruct",
     "defimpl",
     "def.+(.+\/\/.+).+do"
   ],
-
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true
   }

--- a/lib/bonny/application.ex
+++ b/lib/bonny/application.ex
@@ -4,12 +4,15 @@ defmodule Bonny.Application do
   use Application
 
   def start(_type, _args) do
-    children =
+    reconciler = Supervisor.child_spec(Bonny.Reconciler, [])
+
+    watchers =
       Bonny.Config.controllers()
       |> Enum.map(fn controller ->
         Supervisor.child_spec({Bonny.Watcher, controller}, id: controller)
       end)
 
+    children = [reconciler | watchers]
     opts = [strategy: :one_for_one, name: Bonny.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/bonny/controller.ex
+++ b/lib/bonny/controller.ex
@@ -4,12 +4,13 @@ defmodule Bonny.Controller do
 
   > A custom controller is a controller that users can deploy and update on a running cluster, independently of the cluster’s own lifecycle. Custom controllers can work with any kind of resource, but they are especially effective when combined with custom resources. The Operator pattern is one example of such a combination. It allows developers to encode domain knowledge for specific applications into an extension of the Kubernetes API.
 
-  Controllers allow for simple `add`, `modify`, and `delete` handling of custom resources in the Kubernetes API.
+  Controllers allow for simple `add`, `modify`, `delete`, and `reconcile` handling of custom resources in the Kubernetes API.
   """
 
   @callback add(map()) :: :ok | :error | {:error, binary}
   @callback modify(map()) :: :ok | :error | {:error, binary}
   @callback delete(map()) :: :ok | :error | {:error, binary}
+  @callback reconcile(map()) :: :ok | :error | {:error, binary}
 
   @doc false
   defmacro __using__(_opts) do

--- a/lib/bonny/crd.ex
+++ b/lib/bonny/crd.ex
@@ -89,4 +89,15 @@ defmodule Bonny.CRD do
       spec: %{crd | scope: cased_scope}
     }
   end
+
+  @doc false
+  @spec telemetry_metadata(Bonny.CRD.t(), map | nil) :: map
+  def telemetry_metadata(spec = %Bonny.CRD{}, extra \\ %{}) do
+    base = %{
+      api_version: Bonny.CRD.api_version(spec),
+      kind: Bonny.CRD.kind(spec)
+    }
+
+    Map.merge(base, extra)
+  end
 end

--- a/lib/bonny/reconciler.ex
+++ b/lib/bonny/reconciler.ex
@@ -1,0 +1,96 @@
+defmodule Bonny.Reconciler do
+  @moduledoc """
+  Requests all of a CRD's resources and invokes `reconcile/1` on the controller module for each resource.
+  """
+  @client Application.get_env(:bonny, :k8s_client, K8s.Client)
+  @frequency Application.get_env(:bonny, :reconcile_every, 5 * 60 * 1000)
+  @limit Application.get_env(:bonny, :reconcile_batch_size, 50)
+
+  use GenServer
+  require Logger
+  alias Bonny.{Config, CRD, Reconciler}
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  @impl GenServer
+  def init(state) do
+    schedule()
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:run, state) do
+    Logger.debug("Starting reconciliation")
+    Enum.each(Config.controllers(), &Reconciler.run/1)
+
+    schedule()
+    {:noreply, state}
+  end
+
+  defp schedule() do
+    Logger.debug("Scheduling reconciler")
+    Process.send_after(self(), :run, @frequency)
+  end
+
+  @doc false
+  @spec run(module) :: no_return
+  def run(controller, limit \\ @limit) do
+    get_items(controller, limit, nil)
+  end
+
+  @spec get_items(module, integer, nil | :halt | binary) :: no_return
+  defp get_items(_controller, _limit, :halt), do: nil
+
+  defp get_items(controller, limit, continue) do
+    crd_spec = controller.crd_spec
+    api_version = CRD.api_version(crd_spec)
+    name = CRD.kind(crd_spec)
+
+    operation = @client.list(api_version, name, namespace: Config.namespace())
+    params = %{limit: limit, continue: continue}
+    response = @client.run(operation, Config.cluster_name(), params: params)
+
+    case response do
+      {:ok, body} ->
+        Enum.each(body["items"], fn item ->
+          Task.start(fn -> do_reconcile(controller, item) end)
+        end)
+
+        get_items(controller, limit, do_continue(body))
+
+      {:error, reason} ->
+        Logger.error(fn -> "Failed reconciling controller: #{controller}, reason: #{reason}" end)
+        {:error, reason}
+    end
+  end
+
+  @spec do_reconcile(module, map) :: :ok | :error | {:error, binary}
+  defp do_reconcile(controller, item) do
+    {time, result} = Bonny.Telemetry.measure(fn -> controller.reconcile(item) end)
+
+    was_successful =
+      case result do
+        :ok ->
+          true
+
+        :error ->
+          false
+
+        {:error, msg} ->
+          Logger.error(fn -> msg end)
+          false
+      end
+
+    metadata = CRD.telemetry_metadata(controller.crd_spec, %{success: was_successful})
+    Bonny.Telemetry.emit([:reconciler, :reconciled], %{duration: time}, metadata)
+
+    result
+  end
+
+  @spec do_continue(map) :: :halt | binary
+  defp do_continue(%{"metadata" => %{"continue" => ""}}), do: :halt
+  defp do_continue(%{"metadata" => %{"continue" => cont}}) when is_binary(cont), do: cont
+  defp do_continue(_map), do: :halt
+end

--- a/lib/bonny/telemetry.ex
+++ b/lib/bonny/telemetry.ex
@@ -8,7 +8,8 @@ defmodule Bonny.Telemetry do
     [
       [:bonny, :watcher, :initialized],
       [:bonny, :watcher, :started],
-      [:bonny, :watcher, :dispatched]
+      [:bonny, :watcher, :dispatched],
+      [:bonny, :reconciler, :reconciled]
     ]
   end
 
@@ -17,12 +18,7 @@ defmodule Bonny.Telemetry do
 
   Prepends `:bonnny` to all atom lists.
   """
-  @spec emit(list(atom)) :: :ok
-  @spec emit(list(atom), map) :: :ok
   @spec emit(list(atom), map, map) :: :ok
-  def emit(names), do: emit(names, %{}, %{})
-  def emit(names, measurements = %{}), do: emit(names, measurements, %{})
-
   def emit(names, measurements = %{}, metadata = %{}),
     do: :telemetry.execute([:bonny | names], measurements, metadata)
 
@@ -41,7 +37,6 @@ defmodule Bonny.Telemetry do
   def measure(function) do
     {elapsed, retval} = :timer.tc(function)
     seconds = elapsed / 1_000_000
-
     {seconds, retval}
   end
 end

--- a/lib/bonny/watcher/response_buffer.ex
+++ b/lib/bonny/watcher/response_buffer.ex
@@ -1,0 +1,43 @@
+defmodule Bonny.Watcher.ResponseBuffer do
+  @moduledoc """
+  Buffers streaming responses from HTTPoison and returns kubernetes watch events as JSON
+
+  `ResponseBuffer` implementation borrowed from [Kazan](https://github.com/obmarg/kazan)'s LineBuffer.
+  """
+
+  alias __MODULE__
+  @type t :: %__MODULE__{lines: list(binary), pending: binary}
+  defstruct lines: [], pending: ""
+
+  @doc "Create a new `ResponseBuffer`"
+  @spec new() :: __MODULE__.t()
+  def new, do: %ResponseBuffer{}
+
+  @doc "Add an HTTP response chunk to the buffer"
+  @spec add_chunk(__MODULE__.t(), binary) :: __MODULE__.t()
+  def add_chunk(%ResponseBuffer{lines: lines, pending: pending}, chunk) do
+    {new_lines, pending} =
+      case String.last(chunk) do
+        # Final line is complete
+        "\n" ->
+          {String.split(pending <> String.trim_trailing(chunk), "\n"), ""}
+
+        # Final line is not complete
+        _ ->
+          new_lines = String.split(pending <> chunk, "\n")
+          {Enum.drop(new_lines, -1), List.last(new_lines)}
+      end
+
+    %ResponseBuffer{lines: lines ++ new_lines, pending: pending}
+  end
+
+  @doc """
+  Returns complete lines of JSON from streaming HTTP Response.
+
+  Lines are in NDJSON format; each line is a JSON object.
+  """
+  @spec get_lines(__MODULE__.t()) :: {list(binary), __MODULE__.t()}
+  def get_lines(%ResponseBuffer{lines: lines} = buffer) do
+    {lines, %ResponseBuffer{buffer | lines: []}}
+  end
+end

--- a/lib/mix/tasks/bonny.gen.dockerfile.ex
+++ b/lib/mix/tasks/bonny.gen.dockerfile.ex
@@ -5,9 +5,19 @@ defmodule Mix.Tasks.Bonny.Gen.Dockerfile do
 
   use Mix.Task
 
+  @switches [out: :string]
+  @default_opts []
+  @aliases [o: :out]
+
   @shortdoc "Generate operator Dockerfile"
   @spec run([binary()]) :: nil | :ok
-  def run(_) do
-    File.cp!(Mix.Bonny.template("Dockerfile"), "Dockerfile")
+  def run(args) do
+    {opts, _, _} =
+      Mix.Bonny.parse_args(args, @default_opts, switches: @switches, aliases: @aliases)
+
+    "Dockerfile"
+    |> Mix.Bonny.template()
+    |> EEx.eval_file([])
+    |> Mix.Bonny.render(opts[:out])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bonny.MixProject do
     [
       app: :bonny,
       description: description(),
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/priv/templates/bonny.gen/controller.ex
+++ b/priv/templates/bonny.gen/controller.ex
@@ -86,4 +86,14 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
     IO.inspect(payload)
     :ok
   end
+
+  @doc """
+  Called periodically for each existing CustomResource to allow for reconciliation.
+  """
+  @spec reconcile(map()) :: :ok | :error | {:error, binary}
+  @impl Bonny.Controller
+  def reconcile(payload) do
+    IO.inspect(payload)
+    :ok
+  end
 end

--- a/priv/templates/bonny.gen/controller_test.ex
+++ b/priv/templates/bonny.gen/controller_test.ex
@@ -26,4 +26,12 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %>Test do
       assert result == :ok
     end
   end
+
+  describe "reconcile/1" do
+    test "returns :ok" do
+      event = %{}
+      result = <%= mod_name %>.reconcile(event)
+      assert result == :ok
+    end
+  end
 end

--- a/test/bonny/reconciler_test.exs
+++ b/test/bonny/reconciler_test.exs
@@ -1,0 +1,17 @@
+defmodule Bonny.ReconcilerTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Bonny.Reconciler
+
+  describe "run/2" do
+    test "dispatches to the controllers reconcile handler" do
+      Reconciler.run(Whizbang)
+
+      # Professional.
+      :timer.sleep(100)
+
+      events = Whizbang.get(:reconciled)
+      assert events == [%{"page" => 2}, %{"page" => 1}]
+    end
+  end
+end

--- a/test/bonny/watcher/response_buffer_test.exs
+++ b/test/bonny/watcher/response_buffer_test.exs
@@ -1,0 +1,79 @@
+defmodule Bonny.Watcher.ResponseBufferTest do
+  use ExUnit.Case
+  alias Bonny.Watcher.ResponseBuffer
+
+  test "get_lines with nothing" do
+    {events, _buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.get_lines()
+
+    assert [] == events
+  end
+
+  test "get_lines when adding one chunk" do
+    {events, _buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.add_chunk("c1\n")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c1"] == events
+  end
+
+  test "get_lines when adding multiple chunks" do
+    {events, _buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.add_chunk("c1\nc2\n")
+      |> ResponseBuffer.add_chunk("c3\nc4\n")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c1", "c2", "c3", "c4"] == events
+  end
+
+  test "get_lines when adding incomplete chunks" do
+    {events, _buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.add_chunk("c1\nc2\n")
+      |> ResponseBuffer.add_chunk("c3\nc")
+      |> ResponseBuffer.add_chunk("4\nc5\n")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c1", "c2", "c3", "c4", "c5"] == events
+  end
+
+  test "get_lines when in middle of incomplete chunks" do
+    {events, buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.add_chunk("c1\nc2\n")
+      |> ResponseBuffer.add_chunk("c3\nc")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c1", "c2", "c3"] == events
+
+    {events, _buffer} =
+      buffer
+      |> ResponseBuffer.add_chunk("4\nc5\n")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c4", "c5"] == events
+  end
+
+  test "Add empty chunk" do
+    {events, _buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.add_chunk("c1\n")
+      |> ResponseBuffer.add_chunk("")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c1"] == events
+  end
+
+  test "Add just cr chunk" do
+    {events, _buffer} =
+      ResponseBuffer.new()
+      |> ResponseBuffer.add_chunk("c1")
+      |> ResponseBuffer.add_chunk("\n")
+      |> ResponseBuffer.get_lines()
+
+    assert ["c1"] == events
+  end
+end

--- a/test/mix/tasks/bonny.gen.dockerfile_test.exs
+++ b/test/mix/tasks/bonny.gen.dockerfile_test.exs
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.Bonny.Gen.DockerfileTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Mix.Tasks.Bonny.Gen.Dockerfile
+  import ExUnit.CaptureIO
+
+  describe "run/1" do
+    test "generates a Dockerfile" do
+      output =
+        capture_io(fn ->
+          Dockerfile.run(["--out", "-"])
+        end)
+
+      assert output =~ "FROM elixir"
+    end
+  end
+end

--- a/test/support/whizbang.ex
+++ b/test/support/whizbang.ex
@@ -1,3 +1,32 @@
+defmodule Whizbang do
+  @moduledoc false
+  use Bonny.Controller
+  use Agent
+
+  def start_link() do
+    Agent.start_link(fn -> [] end, name: __MODULE__)
+  end
+
+  def get() do
+    Agent.get(__MODULE__, fn events -> events end)
+  end
+
+  def get(type) do
+    Agent.get(__MODULE__, fn events ->
+      Keyword.get_values(events, type)
+    end)
+  end
+
+  def put(event) do
+    Agent.update(__MODULE__, fn events -> [event | events] end)
+  end
+
+  def add(evt), do: put({:added, evt})
+  def modify(evt), do: put({:modified, evt})
+  def delete(evt), do: put({:deleted, evt})
+  def reconcile(evt), do: put({:reconciled, evt})
+end
+
 defmodule V1.Whizbang do
   @moduledoc false
   use Bonny.Controller

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 Bonny.Telemetry.DebugLogger.attach()
+{:ok, _} = Whizbang.start_link()
 ExUnit.start()


### PR DESCRIPTION
* [Added] support for a `reconcile/1` callback.Added support for a
`reconcile/1` callback.
* [ADDED] `reconcile_every` config option to schedule how often to run
reconciliation
* [ADDED] `reconcile_batch_size` to set the size of the HTTP GET limit
when fetching batches of items to reconcile
* [FIXED] receiving `:DOWN` messages no longer crashes Watcher #20
* [FIXED] issue with partially received events #43

Closes #43
Closes #20
Closes #30