### PR TITLE
add additional printer columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add additional printer columns
+
 ## [0.3.2] - 2019-04-15
 
 ### Added

--- a/lib/bonny/controller.ex
+++ b/lib/bonny/controller.ex
@@ -22,6 +22,7 @@ defmodule Bonny.Controller do
       @version nil
       @scope nil
       @names nil
+      @additional_printer_columns nil
       @before_compile Bonny.Controller
     end
   end
@@ -47,8 +48,26 @@ defmodule Bonny.Controller do
           group: @group || Bonny.Config.group(),
           scope: @scope || :namespaced,
           version: @version || version,
-          names: @names || crd_spec_names(name)
+          names: @names || crd_spec_names(name),
+          additionalPrinterColumns: additional_printer_columns()
         }
+      end
+
+      @doc """
+      Columns default
+      """
+      def default_columns() do
+        [
+          %{
+            name: "Age",
+            type: "date",
+            description:
+              "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+            JSONPath: ".metadata.creationTimestamp"
+          }
+        ]
       end
 
       @doc """
@@ -64,6 +83,16 @@ defmodule Bonny.Controller do
 
           [rule | acc]
         end)
+      end
+
+      defp additional_printer_columns() do
+        case @additional_printer_columns do
+          nil ->
+            nil
+
+          some ->
+            some ++ default_columns()
+        end
       end
 
       defp crd_spec_names(name) do

--- a/lib/bonny/crd.ex
+++ b/lib/bonny/crd.ex
@@ -17,12 +17,20 @@ defmodule Bonny.CRD do
           version: String.t()
         }
 
+  @typep columns_t :: %{
+           name: String.t(),
+           type: String.t(),
+           description: String.t(),
+           JSONPath: String.t()
+         }
+
   @typedoc "CRD Spec"
   @type t :: %__MODULE__{
           scope: :namespaced | :cluster,
           group: String.t(),
           names: names_t,
-          version: String.t()
+          version: String.t(),
+          additionalPrinterColumns: list(columns_t)
         }
 
   @enforce_keys [:scope, :group, :names]
@@ -30,7 +38,8 @@ defmodule Bonny.CRD do
   defstruct scope: :namespaced,
             group: nil,
             names: nil,
-            version: nil
+            version: nil,
+            additionalPrinterColumns: nil
 
   @doc """
   CRD Kind or plural name

--- a/priv/templates/bonny.gen/controller.ex
+++ b/priv/templates/bonny.gen/controller.ex
@@ -40,6 +40,26 @@ defmodule <%= app_name %>.Controller.<%= version %>.<%= mod_name %> do
   @rule {"", ["pods", "secrets"], ["*"]}
   @rule {"apiextensions.k8s.io", ["foo"], ["*"]}
   ```
+
+  ## Add additional printer columns
+
+  Kubectl uses server-side printing. Columns can be declared using `@additional_printer_columns` and generated using `mix bonny.manifest`
+
+  [Additional Printer Columns docs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#additional-printer-columns)
+
+  ### Examples
+  
+  ```
+  @additional_printer_columns [
+    %{
+      name: "test",
+      type: "string",
+      description: "test",
+      JSONPath: ".spec.test"
+    }
+  ]
+  ```
+  
   """
   use Bonny.Controller
 

--- a/test/bonny/controller_test.exs
+++ b/test/bonny/controller_test.exs
@@ -33,6 +33,30 @@ defmodule Bonny.ControllerTest do
 
       assert crd_spec == V2.Whizbang.crd_spec()
     end
+
+    test "with custom columns" do
+      crd_spec = %Bonny.CRD{
+        group: "kewl.example.io",
+        scope: :cluster,
+        version: "v2alpha1",
+        names: %{
+          plural: "foos",
+          singular: "foo",
+          kind: "Foo"
+        },
+        additionalPrinterColumns:
+          [
+            %{
+              name: "test",
+              type: "string",
+              description: "test",
+              JSONPath: ".spec.test"
+            }
+          ] ++ V3.Whizbang.default_columns()
+      }
+
+      assert crd_spec == V3.Whizbang.crd_spec()
+    end
   end
 
   describe "rules/0" do

--- a/test/support/whizbang.ex
+++ b/test/support/whizbang.ex
@@ -57,3 +57,30 @@ defmodule V2.Whizbang do
   def delete(_), do: :ok
   def reconcile(_), do: :ok
 end
+
+defmodule V3.Whizbang do
+  @moduledoc false
+  use Bonny.Controller
+
+  @version "v2alpha1"
+  @group "kewl.example.io"
+  @scope :cluster
+  @names %{
+    plural: "foos",
+    singular: "foo",
+    kind: "Foo"
+  }
+  @additional_printer_columns [
+    %{
+      name: "test",
+      type: "string",
+      description: "test",
+      JSONPath: ".spec.test"
+    }
+  ]
+
+  def add(_), do: :ok
+  def modify(_), do: :ok
+  def delete(_), do: :ok
+  def reconcile(_), do: :ok
+end


### PR DESCRIPTION
I implemented customs columns for kubectl.

Official documentation: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#additional-printer-columns