### PR TITLE
Build deps before lib/priv copy, improving build times for future builds

### DIFF
--- a/priv/templates/bonny.gen/Dockerfile
+++ b/priv/templates/bonny.gen/Dockerfile
@@ -2,7 +2,7 @@
 ###### Build Image ######
 #########################
 
-FROM bitwalker/alpine-elixir:1.9.1 as builder
+FROM bitwalker/alpine-elixir:1.9.4 as builder
 
 ENV MIX_ENV=prod \
   MIX_HOME=/opt/mix \
@@ -13,9 +13,15 @@ RUN mix local.hex --force && \
 
 WORKDIR /app
 
-COPY . .
+COPY mix.lock mix.exs ./
+COPY config config
 
-RUN mix deps.get --only-prod && mix release
+RUN mix deps.get --only-prod && mix deps.compile
+
+COPY priv priv
+COPY lib lib
+
+RUN mix release
 
 #########################
 ##### Release Image #####


### PR DESCRIPTION
Brings build time of `mix bonny.gen.manifest --image <image>` from ~70 seconds to < 10.

**Note:** It _will_ take the full time if dependencies or configs are modified because that layer must be rebuilt.

Also bumps version of builder image from 1.9.1 to 1.9.4.

Requires `mix bonny.gen.dockerfile` to take effect