### PR TITLE
add config.exs option for namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ config :bonny,
   # K8s.Cluster to use, defaults to :default
   cluster_name: :default,
 
+  # The namespace to watch for Namespaced CRDs.
+  # Defaults to "default". `:all` for all namespaces
+  # Also configurable via environment variable `BONNY_POD_NAMESPACE`
+  namespace: "default",
+
   # Set the Kubernetes API group for this operator.
   # This can be overwritten using the @group attribute of a controller
   group: "your-operator.example.com",

--- a/lib/bonny/config.ex
+++ b/lib/bonny/config.ex
@@ -104,7 +104,7 @@ defmodule Bonny.Config do
   """
   @spec namespace() :: binary
   def namespace() do
-    System.get_env("BONNY_POD_NAMESPACE") || "default"
+    Application.get_env(:bonny, :namespace, System.get_env("BONNY_POD_NAMESPACE", "default"))
   end
 
   @doc """

--- a/lib/bonny/config.ex
+++ b/lib/bonny/config.ex
@@ -111,7 +111,11 @@ defmodule Bonny.Config do
   """
   @spec namespace() :: binary
   def namespace() do
-    Application.get_env(:bonny, :namespace, System.get_env("BONNY_POD_NAMESPACE", "default"))
+    case System.get_env("BONNY_POD_NAMESPACE") do
+      nil -> Application.get_env(:bonny, :namespace, "default")
+      "__ALL__" -> :all
+      namespace -> namespace
+    end
   end
 
   @doc """

--- a/lib/bonny/config.ex
+++ b/lib/bonny/config.ex
@@ -96,7 +96,9 @@ defmodule Bonny.Config do
   This can be set via environment variable:
 
   ```shell
-  BONNY_POD_NAMESPACE=prod
+  BONNY_POD_NAMESPACE=prod # specific namespace
+  # or
+  BONNY_POD_NAMESPACE=__ALL__ # all namespaces
   iex -S mix
   ```
 
@@ -106,6 +108,8 @@ defmodule Bonny.Config do
   # or
   config :bonny; namespace: :all # all namespaces
   ```
+
+  Configuration via environment variable always takes precedence over config.exs.
 
   Bonny sets `BONNY_POD_NAMESPACE` on all Kubernetes deployments to the namespace the operator is deployed in.
   """

--- a/lib/bonny/config.ex
+++ b/lib/bonny/config.ex
@@ -100,6 +100,13 @@ defmodule Bonny.Config do
   iex -S mix
   ```
 
+  Or via config.exs:
+  ```
+  config :bonny, namespace: "mynamespace" # specific namespace
+  # or
+  config :bonny; namespace: :all # all namespaces
+  ```
+
   Bonny sets `BONNY_POD_NAMESPACE` on all Kubernetes deployments to the namespace the operator is deployed in.
   """
   @spec namespace() :: binary

--- a/test/bonny/config_test.exs
+++ b/test/bonny/config_test.exs
@@ -83,7 +83,11 @@ defmodule Bonny.ConfigTest do
 
   describe "namespace/0" do
     test "returns 'default' when not set" do
+      original = Application.get_env(:bonny, :namespace)
+
+      Application.delete_env(:bonny, :namespace)
       assert Config.namespace() == "default"
+      Application.put_env(:bonny, :namespace, original)
     end
 
     test "can be set via config.exs" do

--- a/test/bonny/config_test.exs
+++ b/test/bonny/config_test.exs
@@ -99,6 +99,23 @@ defmodule Bonny.ConfigTest do
       assert Config.namespace() == "prod"
       System.delete_env("BONNY_POD_NAMESPACE")
     end
+
+    test "can be set to :all via env variable" do
+      System.put_env("BONNY_POD_NAMESPACE", "__ALL__")
+      assert Config.namespace() == :all
+      System.delete_env("BONNY_POD_NAMESPACE")
+    end
+
+    test "config.exs configuration is preceded by env" do
+      original = Application.get_env(:bonny, :namespace)
+
+      System.put_env("BONNY_POD_NAMESPACE", "prod")
+      Application.put_env(:bonny, :namespace, "my-cool-namespace")
+      assert Config.namespace() == "prod"
+      System.delete_env("BONNY_POD_NAMESPACE")
+      assert Config.namespace() == "my-cool-namespace"
+      Application.put_env(:bonny, :namespace, original)
+    end
   end
 
   describe "controllers/0" do

--- a/test/bonny/config_test.exs
+++ b/test/bonny/config_test.exs
@@ -86,6 +86,14 @@ defmodule Bonny.ConfigTest do
       assert Config.namespace() == "default"
     end
 
+    test "can be set via config.exs" do
+      original = Application.get_env(:bonny, :namespace)
+
+      Application.put_env(:bonny, :namespace, :all)
+      assert Config.namespace() == :all
+      Application.put_env(:bonny, :namespace, original)
+    end
+
     test "can be set by env variable" do
       System.put_env("BONNY_POD_NAMESPACE", "prod")
       assert Config.namespace() == "prod"


### PR DESCRIPTION
My primary reason for this PR is to be able to pass `:all` to namespace.
This makes it possible to use a single controller for namespaced resources, instead of having to deploy one per namespace or use cluster-level resources