### PR TITLE
Clean compilation warnings on 1.12.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,5 +12,9 @@ jobs:
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
+      - name: Compile
+        run: |
+          mix clean
+          mix compile --warnings-as-errors
       - name: Run Tests
         run: mix test

--- a/lib/bonny/controller.ex
+++ b/lib/bonny/controller.ex
@@ -63,16 +63,22 @@ defmodule Bonny.Controller do
         @moduledoc "Controller watcher implementation"
         use Bonny.Server.Watcher
 
+        @impl Bonny.Server.Watcher
         defdelegate add(resource), to: controller
+        @impl Bonny.Server.Watcher
         defdelegate modify(resource), to: controller
+        @impl Bonny.Server.Watcher
         defdelegate delete(resource), to: controller
+        @impl Bonny.Server.Watcher
         defdelegate watch_operation(), to: controller, as: :list_operation
       end
 
       defmodule ReconcileServer do
         @moduledoc "Controller reconciler implementation"
         use Bonny.Server.Reconciler, frequency: 30
+        @impl Bonny.Server.Reconciler
         defdelegate reconcile(resource), to: controller
+        @impl Bonny.Server.Reconciler
         defdelegate reconcile_operation(), to: controller, as: :list_operation
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Bonny.MixProject do
       preferred_cli_env: [coveralls: :test, "coveralls.travis": :test, "coveralls.html": :test],
       docs: docs(),
       package: package(),
-      dialyzer: [plt_add_apps: [:mix, :eex]]
+      dialyzer: [plt_add_apps: [:mix, :eex]],
+      xref: [exclude: [EEx]]
     ]
   end
 
@@ -37,7 +38,8 @@ defmodule Bonny.MixProject do
       {:k8s, "~> 0.4.0"},
       {:notion, "~> 0.2"},
       {:telemetry, ">= 0.4.0"},
-      {:ymlr, "~> 1.0"}, # 2.0 only supports Elixir >= 1.11
+      #  2.0 only supports Elixir >= 1.11
+      {:ymlr, "~> 1.0"},
 
       # Dev deps
       {:mix_test_watch, "~> 0.8", only: :dev, runtime: false},


### PR DESCRIPTION
On upgrading code with a bonny controller I started getting new compilation errors, These errors all pointed to line one of a controller module. Errors like this:
```
warning: module attribute @impl was not set for function watch_operation/0 callback (specified in Bonny.Server.Watcher).
```
However line one didn't contain any of the code referenced. The closest non documentation code was

```
use Bonny.Controller
```

I suspect that the errors are coming from the expanded code via `defmacro`
code in lib/bonny/controller.ex. This commit cleans file and gets the whole code base
clean. Then adds on a github action to make sure it's checked.