### PR TITLE
Update Elixir version and update from Mix.Config to Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.7.4-alpine
+FROM elixir:1.13.2-alpine
 
 RUN mix local.hex --force && \
   mix local.rebar --force

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-if Mix.env() == :test do
+if config_env() == :test do
   config :logger, level: :error
 
   config :k8s,
@@ -15,7 +15,7 @@ if Mix.env() == :test do
     api_version: "apiextensions.k8s.io/v1beta1"
 end
 
-if Mix.env() == :dev do
+if config_env() == :dev do
   config :logger, level: :debug
 
   config :mix_test_watch,


### PR DESCRIPTION
This updates the elixir version in the Dockerfile, and also
adopts the new `Config` module in order to avoid
deprecation warnings

Note:  We should seriously consider removing `config` entirely from the
project as config is global state and is not the preferred way to do
things for libraries now.
See: https://github.com/elixir-lang/elixir/issues/8815