### PR TITLE
Use name instead of service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.1] - 2022-05-25
 
+## Updated
+
+- Use name of application in Deployments instead of service account name.
+
 ### Fixed
 
 - Add missing `priv` folder to package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.5.1] - 2022-05-25
-
 ## Updated
 
 - Use name of application in Deployments instead of service account name.
+
+## [0.5.1] - 2022-05-25
 
 ### Fixed
 

--- a/lib/bonny/operator.ex
+++ b/lib/bonny/operator.ex
@@ -99,7 +99,7 @@ defmodule Bonny.Operator do
       kind: "Deployment",
       metadata: %{
         labels: labels(),
-        name: Bonny.Config.service_account(),
+        name: Bonny.Config.name(),
         namespace: namespace
       },
       spec: %{


### PR DESCRIPTION
I think it's better to use the app name instead of the serviceaccount name as the deployment name