### PR TITLE
Start app so controller modules are available

### DIFF
--- a/lib/mix/tasks/bonny.gen.manifest.ex
+++ b/lib/mix/tasks/bonny.gen.manifest.ex
@@ -32,6 +32,8 @@ defmodule Mix.Tasks.Bonny.Gen.Manifest do
   """
 
   use Mix.Task
+  @requirements ["app.start"]
+
   alias Bonny.Operator
 
   @default_opts [namespace: "default", local: false]


### PR DESCRIPTION
## Steps to reproduce
erlang 24.3.4.5
elixir 1.13.4-otp-24

1. Generate a controller -- `mix bonny.gen.controller Widgets widgets`
2. Generate a manifest -- `mix bonny.gen.manifest` 

## Expected results
Generate a manifest.yaml

## Actual results

```
** (UndefinedFunctionError) function MyApp.Controller.V1.Widget.crd/0 is undefined (module 
MyApp.Controller.V1.Widget is not available)
    MyApp.Controller.V1.Widget.crd()
    (bonny 0.5.2) lib/bonny/operator.ex:65: anonymous fn/1 in Bonny.Operator.crds/0
    (elixir 1.13.4) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    (bonny 0.5.2) lib/mix/tasks/bonny.gen.manifest.ex:70: Mix.Tasks.Bonny.Gen.Manifest.resource_manifests/1
    (bonny 0.5.2) lib/mix/tasks/bonny.gen.manifest.ex:52: Mix.Tasks.Bonny.Gen.Manifest.run/1
    (mix 1.13.4) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.13.4) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

## Proposed Fix
- Start app to make controller classes available
