### PR TITLE
Leader Election: Add missing permission to access leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+## [1.1.3] - 2023-04-09
+
+- Leader Election: Add missing RBAC permission to access leases - [#207](https://github.com/coryodaniel/bonny/pull/207)
+
 ## [1.1.2] - 2023-03-07
 
 ### Added

--- a/lib/mix/operator.ex
+++ b/lib/mix/operator.ex
@@ -32,6 +32,11 @@ defmodule Bonny.Mix.Operator do
         apiGroups: ["events.k8s.io"],
         resources: ["events"],
         verbs: ["*"]
+      },
+      %{
+        apiGroups: ["coordination.k8s.io"],
+        resources: ["leases"],
+        verbs: ["*"]
       }
     ]
   end

--- a/test/mix/operator_test.exs
+++ b/test/mix/operator_test.exs
@@ -17,6 +17,7 @@ defmodule Bonny.Mix.OperatorTest do
           verbs: ["*"]
         },
         %{apiGroups: ["events.k8s.io"], resources: ["events"], verbs: ["*"]},
+        %{apiGroups: ["coordination.k8s.io"], resources: ["leases"], verbs: ["*"]},
         %{apiGroups: ["example.com"], resources: ["widgets"], verbs: ["*"]},
         %{apiGroups: ["example.com"], resources: ["cogs"], verbs: ["*"]},
         %{apiGroups: ["example.com"], resources: ["whizbangs"], verbs: ["*"]},


### PR DESCRIPTION
In order for the leader election to work, the operator needs access to resources of type `coordination.k8s.io/leases`.