### PR TITLE
introduce group option to apply descendants in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Changed
+
+- `Bonny.Axn.register_descendant/3` - Add option `group` to define in what group to apply a descendant and apply descendants in groups.
+
+<!-- No new entries below this line! -->
+
 ## [1.2.1] - 2023-06-126
 
 ### Fixed
@@ -27,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `mix bonny.gen.manifest` - Merge RBAC rules for the same resources - [#213](https://github.com/coryodaniel/bonny/pull/213)
 - Compile time dependency at runtime - [#212](https://github.com/coryodaniel/bonny/pull/212)
-
-<!-- No new entries below this line! -->
 
 ## [1.1.3] - 2023-04-09
 

--- a/test/bonny/axn_test.exs
+++ b/test/bonny/axn_test.exs
@@ -418,7 +418,7 @@ defmodule Bonny.AxnTest do
   describe "register_descendant/3" do
     test "registers a descendant with owner reference", %{axn: axn, related: related} do
       %{descendants: descendants} = MUT.register_descendant(axn, related)
-      [registered_descendant | others] = Map.values(descendants)
+      [{_, registered_descendant} | others] = Map.values(descendants)
 
       assert Enum.empty?(others)
 
@@ -440,7 +440,7 @@ defmodule Bonny.AxnTest do
 
     test "Ommits owner reference if requested", %{axn: axn, related: related} do
       %{descendants: descendants} = MUT.register_descendant(axn, related, omit_owner_ref: true)
-      [registered_descendant | []] = Map.values(descendants)
+      [{_, registered_descendant} | []] = Map.values(descendants)
       assert is_nil(registered_descendant["metadata"]["ownerReferences"])
     end
 


### PR DESCRIPTION
Adds a `group` option to `Bonny.Axn.register_descendant/3`. This option controls in what group the descendant is applied.  Groups are applied in ascending order. Resources within a group are applied simultaneously.

This option only needs to be specified if some resources must exist before others can be applied. 

### Example

```elixir
  ns = %{
    "apiVersion" => "v1",
    "kind" => "namespace",
    "metadata" => %{"name" => "my_ns"}
  }
  pod = %{
    "apiVersion" => "v1",
    "kind" => "pod",
    "metadata" => %{"namespace" => "my_ns", "name" => "my_pod"},
    ...
  }

  axn
  |> Bonny.Axn.register_descendant(resource, ns, group: -1, omit_owner_ref: true)
  |> Bonny.Axn.register_descendant(resource, pod)

``` 

Solves #232.