### PR TITLE
Implements telemetry for the Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
 
+### Added
+
+- Added telemetry events to the Operator module - [#244](https://github.com/coryodaniel/bonny/pull/244)
+
 <!-- No new entries below this line! -->
 
 ## [1.3.0] - 2023-09-25

--- a/lib/bonny/operator.ex
+++ b/lib/bonny/operator.ex
@@ -168,7 +168,7 @@ defmodule Bonny.Operator do
       |> Bonny.Axn.emit_events()
       |> Bonny.Axn.run_after_processed()
 
-      {:ok, %{metadata}}
+      {:ok, metadata}
     end)
   end
 

--- a/lib/bonny/operator.ex
+++ b/lib/bonny/operator.ex
@@ -145,18 +145,31 @@ defmodule Bonny.Operator do
   @doc false
   @spec run({atom(), Bonny.Resource.t()}, {module(), keyword()}, module(), K8s.Conn.t()) :: :ok
   def run({action, resource}, controller, operator, conn) do
-    Axn.new!(
-      conn: conn,
-      action: action,
-      resource: resource,
+    metadata = %{
+      operator: operator,
       controller: controller,
-      operator: operator
-    )
-    |> operator.call([])
-    |> Bonny.Axn.emit_events()
-    |> Bonny.Axn.run_after_processed()
+      action: action,
+      name: K8s.Resource.name(resource),
+      namespace: K8s.Resource.namespace(resource),
+      kind: K8s.Resource.kind(resource),
+      api_version: resource["apiVersion"],
+      library: :bonny
+    }
 
-    :ok
+    :telemetry.span([:operator, :run], metadata, fn ->
+      Axn.new!(
+        conn: conn,
+        action: action,
+        resource: resource,
+        controller: controller,
+        operator: operator
+      )
+      |> operator.call([])
+      |> Bonny.Axn.emit_events()
+      |> Bonny.Axn.run_after_processed()
+
+      {:ok, %{metadata}}
+    end)
   end
 
   @doc false

--- a/lib/bonny/server/watcher.ex
+++ b/lib/bonny/server/watcher.ex
@@ -44,10 +44,12 @@ defmodule Bonny.Server.Watcher do
        ) do
     metadata = %{
       module: controller,
+      type: type,
       name: K8s.Resource.name(resource),
       namespace: K8s.Resource.namespace(resource),
       kind: K8s.Resource.kind(resource),
-      api_version: resource["apiVersion"]
+      api_version: resource["apiVersion"],
+      library: :bonny
     }
 
     :telemetry.span([:watcher, :watch], metadata, fn ->

--- a/lib/bonny/sys/telemetry.ex
+++ b/lib/bonny/sys/telemetry.ex
@@ -7,7 +7,8 @@ defmodule Bonny.Sys.Telemetry do
     [:reconciler, :reconcile],
     [:watcher, :watch],
     [:scheduler, :binding],
-    [:task, :execution]
+    [:task, :execution],
+    [:operator, :run]
   ]
 
   @events Enum.flat_map(@spans, fn span ->


### PR DESCRIPTION
Hi, first of all thanks this great project.

The Operator doesn't use the Reconciler's and Watcher's execution logic, it reimplements it directly from `get_raw_stream` to work better with ControllerV2, but that means that we don't get telemetry data when using an Operator.

This adds telemetry support for the Operator runs.



