### PR TITLE
feature safe-apply-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Add your changelog entry to the relevant subsection -->
 
 <!-- ### Added | Changed | Deprecated | Removed | Fixed | Security -->
+### Added
+
+- `Bonny.Pluggable.ApplyStatus`: Added `safe_mode` option to gracefully handle `NotFound` errors when a resource is deleted during reconciliation. Instead of crashing, a warning is logged and reconciliation continues. Defaults to `false` for backwards compatibility. Can be configured globally via `config :bonny, apply_status_safe_mode: true`. Recommended to enable in production - [#335](https://github.com/coryodaniel/bonny/pull/335)
+- `Bonny.Axn.safe_apply_status/2`: New function that applies resource status while gracefully handling `NotFound` errors - [#335](https://github.com/coryodaniel/bonny/pull/335)
+
 ### Changed
 
 - Cluster-scoped resources (resources without a namespace) will  automatically have owner references omitted [#321](https://github.com/coryodaniel/bonny/pull/321)

--- a/lib/bonny/axn.ex
+++ b/lib/bonny/axn.ex
@@ -381,17 +381,95 @@ defmodule Bonny.Axn do
         mark_status_applied(axn)
 
       {:error, error} ->
-        id = identifier(axn)
-        message = apply_status_error_message(error)
-
-        Logger.error("#{inspect(id)} - #{message}",
-          library: :bonny,
-          resource: resource,
-          error: error
-        )
-
-        raise "#{inspect(id)} - #{message}"
+        raise_apply_status_error(axn, resource, error)
     end
+  end
+
+  @doc """
+  Applies the status to the resource's status subresource in the cluster,
+  gracefully handling "NotFound" errors.
+
+  This is useful for operators where a resource may be deleted while
+  reconciliation is still in progress. When the status update fails because
+  the resource no longer exists, a warning is logged and the unmodified
+  `axn` is returned instead of raising.
+
+  All other errors still raise as in `apply_status/2`.
+
+  ## Options
+
+  Same as `apply_status/2`: `:field_manager`, `:force`, etc.
+
+  ## Examples
+
+      # In a controller step
+      Bonny.Axn.safe_apply_status(axn, field_manager: "MyOperator", force: true)
+  """
+  @spec safe_apply_status(t(), Keyword.t()) :: t()
+  def safe_apply_status(axn, apply_opts \\ [])
+
+  def safe_apply_status(axn, _) when is_status_applied(axn) do
+    raise StatusAlreadyAppliedError
+  end
+
+  def safe_apply_status(%__MODULE__{status: nil} = axn, _) do
+    mark_status_applied(axn)
+  end
+
+  def safe_apply_status(%Bonny.Axn{resource: resource} = axn, apply_opts) do
+    axn = put_in(axn.resource["status"], axn.status)
+
+    result =
+      axn.resource
+      |> run_before_apply_status(axn)
+      |> Resource.apply_status(axn.conn, apply_opts)
+
+    case result do
+      {:ok, _} ->
+        mark_status_applied(axn)
+
+      {:error, %{message: message} = error} when is_binary(message) ->
+        if String.contains?(message, "not found") do
+          log_notfound_warning(axn)
+          axn
+        else
+          raise_apply_status_error(axn, resource, error)
+        end
+
+      {:error, error} ->
+        raise_apply_status_error(axn, resource, error)
+    end
+  end
+
+  defp raise_apply_status_error(axn, resource, error) do
+    id = identifier(axn)
+    message = apply_status_error_message(error)
+
+    Logger.error("#{inspect(id)} - #{message}",
+      library: :bonny,
+      resource: resource,
+      error: error
+    )
+
+    raise "#{inspect(id)} - #{message}"
+  end
+
+  defp log_notfound_warning(axn) do
+    resource_kind = axn.resource["kind"]
+    resource_name = get_in(axn.resource, ["metadata", "name"])
+    resource_namespace = get_in(axn.resource, ["metadata", "namespace"])
+
+    location =
+      if resource_namespace do
+        "#{resource_kind}/#{resource_name} in namespace #{resource_namespace}"
+      else
+        "#{resource_kind}/#{resource_name}"
+      end
+
+    Logger.warning(
+      "Skipping status update for #{location} - resource was deleted during reconciliation",
+      library: :bonny
+    )
   end
 
   defp apply_error_message(%{message: message}), do: [" ", message]

--- a/lib/bonny/pluggable/apply_status.ex
+++ b/lib/bonny/pluggable/apply_status.ex
@@ -2,23 +2,43 @@ defmodule Bonny.Pluggable.ApplyStatus do
   @moduledoc """
   Applies the status of the given `%Bonny.Axn{}` struct to the status subresource.
 
-  ## Options
+  ## Options
 
     * `:force` and `:field_manager` - Options forwarded to `K8s.Client.apply()`.
+    * `:safe_mode` - When `true`, gracefully handles "NotFound" errors that occur when
+      a resource is deleted during reconciliation. Instead of crashing, a warning is
+      logged and reconciliation continues. Defaults to `false` for backwards compatibility.
+      See `Bonny.Axn.safe_apply_status/2` for details.
+      **Recommended to set to `true` in production** to avoid crashes when resources
+      are deleted while being reconciled.
 
-  ## Examples
+  ## Examples
 
+      # Standard usage
       step Bonny.Pluggable.ApplyStatus, field_manager: "MyOperator", force: true
+
+      # With safe mode enabled (recommended for production)
+      step Bonny.Pluggable.ApplyStatus, safe_mode: true, field_manager: "MyOperator"
   """
 
   @behaviour Pluggable
 
   @impl true
-  def init(opts \\ []), do: Keyword.take(opts, [:field_manager, :force])
+  def init(opts \\ []) do
+    opts
+    |> Keyword.validate!([:field_manager, :force, :safe_mode])
+    |> Keyword.put_new(:safe_mode, Application.get_env(:bonny, :apply_status_safe_mode, false))
+  end
 
   @impl true
   def call(axn, apply_opts) when axn.action != :delete do
-    Bonny.Axn.apply_status(axn, apply_opts)
+    {safe_mode, k8s_opts} = Keyword.pop!(apply_opts, :safe_mode)
+
+    if safe_mode do
+      Bonny.Axn.safe_apply_status(axn, k8s_opts)
+    else
+      Bonny.Axn.apply_status(axn, k8s_opts)
+    end
   end
 
   def call(axn, _apply_opts), do: axn

--- a/lib/bonny/pluggable/apply_status.ex
+++ b/lib/bonny/pluggable/apply_status.ex
@@ -7,10 +7,20 @@ defmodule Bonny.Pluggable.ApplyStatus do
     * `:force` and `:field_manager` - Options forwarded to `K8s.Client.apply()`.
     * `:safe_mode` - When `true`, gracefully handles "NotFound" errors that occur when
       a resource is deleted during reconciliation. Instead of crashing, a warning is
-      logged and reconciliation continues. Defaults to `false` for backwards compatibility.
-      See `Bonny.Axn.safe_apply_status/2` for details.
+      logged and reconciliation continues. Defaults to the value of
+      `Application.get_env(:bonny, :apply_status_safe_mode, false)`, falling back to
+      `false` for backwards compatibility. See `Bonny.Axn.safe_apply_status/2` for details.
       **Recommended to set to `true` in production** to avoid crashes when resources
       are deleted while being reconciled.
+
+  ## Global configuration
+
+  You can set a default for `safe_mode` across all pipelines in your config:
+
+      config :bonny,
+        apply_status_safe_mode: true
+
+  Per-step options always take precedence over the global config.
 
   ## Examples
 

--- a/test/bonny/axn_test.exs
+++ b/test/bonny/axn_test.exs
@@ -1,9 +1,11 @@
 defmodule Bonny.AxnTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Bonny.Axn, as: MUT
 
   alias Bonny.Test.ResourceHelper
+
+  require Logger
 
   setup do
     conn = Bonny.Config.conn()
@@ -412,6 +414,137 @@ defmodule Bonny.AxnTest do
         |> MUT.apply_status()
         |> MUT.apply_status()
       end
+    end
+  end
+
+  describe "safe_apply_status/2" do
+    defmodule SafeApplyStatusK8sMock do
+      require Logger
+      import K8s.Client.HTTPTestHelper
+      alias Bonny.Test.ResourceHelper
+
+      def request(:patch, %URI{} = uri, body, _headers, _opts) do
+        resource = Jason.decode!(body)
+
+        case get_in(resource, ["status", "scenario"]) do
+          "ok" ->
+            if ref = get_in(resource, ["status", "ref"]) do
+              send(self(), {:status_applied, ResourceHelper.string_to_ref(ref), uri.query})
+            end
+
+            render(resource)
+
+          "not_found" ->
+            name = get_in(resource, ["metadata", "name"])
+            {:error, %K8s.Client.HTTPError{message: ~s|resource "#{name}" not found|}}
+
+          "other_error" ->
+            {:error, %K8s.Client.HTTPError{message: "some error"}}
+
+          other ->
+            {:error, %K8s.Client.HTTPError{message: "invalid status.scenario: #{inspect(other)}"}}
+        end
+      end
+
+      def request(_method, _uri, _body, _headers, _opts) do
+        Logger.error("Call to #{__MODULE__}.request/5 not handled: #{inspect(binding())}")
+        {:error, %K8s.Client.HTTPError{message: "request not mocked"}}
+      end
+    end
+
+    setup do
+      K8s.Client.DynamicHTTPProvider.register(self(), SafeApplyStatusK8sMock)
+      previous_level = Logger.level()
+      Logger.configure(level: :debug)
+      on_exit(fn -> Logger.configure(level: previous_level) end)
+      :ok
+    end
+
+    test "applies status successfully", %{axn: axn} do
+      ref = make_ref()
+
+      result =
+        axn
+        |> MUT.update_status(fn _ ->
+          %{"scenario" => "ok", "ref" => ResourceHelper.to_string(ref)}
+        end)
+        |> MUT.safe_apply_status()
+
+      assert_receive {:status_applied, ^ref, _}
+      assert result.resource["status"]["scenario"] == "ok"
+    end
+
+    test "logs warning and returns axn on NotFound error", %{axn: axn} do
+      log =
+        ExUnit.CaptureLog.capture_log([level: :debug], fn ->
+          result =
+            axn
+            |> MUT.update_status(fn _ -> %{"scenario" => "not_found"} end)
+            |> MUT.safe_apply_status()
+
+          # Returns axn without marking status as applied
+          assert result.status == %{"scenario" => "not_found"}
+          assert result.resource["status"] == %{"scenario" => "not_found"}
+        end)
+
+      assert log =~
+               "Skipping status update for ConfigMap/foo in namespace default - resource was deleted during reconciliation"
+    end
+
+    test "logs warning without namespace for cluster-scoped resources" do
+      conn = Bonny.Config.conn()
+
+      cluster_resource = %{
+        "apiVersion" => "example.com/v1",
+        "kind" => "Widget",
+        "metadata" => %{
+          "name" => "my-widget",
+          "uid" => "widget-uid",
+          "generation" => 1
+        }
+      }
+
+      axn = MUT.new!(action: :add, resource: cluster_resource, conn: conn)
+
+      log =
+        ExUnit.CaptureLog.capture_log([level: :debug], fn ->
+          _result =
+            axn
+            |> MUT.update_status(fn _ -> %{"scenario" => "not_found"} end)
+            |> MUT.safe_apply_status()
+        end)
+
+      assert log =~
+               "Skipping status update for Widget/my-widget - resource was deleted during reconciliation"
+
+      refute log =~ "namespace"
+    end
+
+    test "re-raises non-NotFound errors", %{axn: axn} do
+      assert_raise RuntimeError, ~r/some error/, fn ->
+        axn
+        |> MUT.update_status(fn _ -> %{"scenario" => "other_error"} end)
+        |> MUT.safe_apply_status()
+      end
+    end
+
+    test "raises StatusAlreadyAppliedError when status already applied", %{axn: axn} do
+      ref = make_ref()
+
+      assert_raise Bonny.Axn.StatusAlreadyAppliedError, fn ->
+        axn
+        |> MUT.update_status(fn _ ->
+          %{"scenario" => "ok", "ref" => ResourceHelper.to_string(ref)}
+        end)
+        |> MUT.safe_apply_status()
+        |> MUT.safe_apply_status()
+      end
+    end
+
+    test "marks status applied (noop) when status is nil", %{axn: axn} do
+      result = MUT.safe_apply_status(axn)
+      # status is nil, so it should just mark as applied (noop)
+      assert result != axn
     end
   end
 

--- a/test/bonny/pluggable/apply_status_test.exs
+++ b/test/bonny/pluggable/apply_status_test.exs
@@ -55,8 +55,24 @@ defmodule Bonny.Pluggable.ApplyStatusTest do
   end
 
   describe "init/1" do
-    test "defaults safe_mode to false" do
+    test "defaults safe_mode to false when no global config is set" do
       opts = MUT.init()
+      assert opts[:safe_mode] == false
+    end
+
+    test "uses global config for safe_mode default" do
+      Application.put_env(:bonny, :apply_status_safe_mode, true)
+      on_exit(fn -> Application.delete_env(:bonny, :apply_status_safe_mode) end)
+
+      opts = MUT.init()
+      assert opts[:safe_mode] == true
+    end
+
+    test "per-step option takes precedence over global config" do
+      Application.put_env(:bonny, :apply_status_safe_mode, true)
+      on_exit(fn -> Application.delete_env(:bonny, :apply_status_safe_mode) end)
+
+      opts = MUT.init(safe_mode: false)
       assert opts[:safe_mode] == false
     end
 

--- a/test/bonny/pluggable/apply_status_test.exs
+++ b/test/bonny/pluggable/apply_status_test.exs
@@ -1,0 +1,152 @@
+defmodule Bonny.Pluggable.ApplyStatusTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  use Bonny.Axn.Test
+
+  import ExUnit.CaptureLog
+
+  require Logger
+
+  alias Bonny.Pluggable.ApplyStatus, as: MUT
+  alias Bonny.Test.ResourceHelper
+
+  defmodule K8sMock do
+    require Logger
+    import K8s.Client.HTTPTestHelper
+    alias Bonny.Test.ResourceHelper
+
+    def request(:patch, %URI{} = uri, body, _headers, _opts) do
+      resource = Jason.decode!(body)
+
+      case get_in(resource, ["status", "scenario"]) do
+        "ok" ->
+          if ref = get_in(resource, ["status", "ref"]) do
+            send(self(), {:status_applied, ResourceHelper.string_to_ref(ref), uri.query})
+          end
+
+          render(resource)
+
+        "not_found" ->
+          name = get_in(resource, ["metadata", "name"])
+          {:error, %K8s.Client.HTTPError{message: ~s|resource "#{name}" not found|}}
+
+        "other_error" ->
+          {:error, %K8s.Client.HTTPError{message: "some error"}}
+
+        other ->
+          {:error, %K8s.Client.HTTPError{message: "invalid status.scenario: #{inspect(other)}"}}
+      end
+    end
+
+    def request(_method, _uri, _body, _headers, _opts) do
+      Logger.error("Call to #{__MODULE__}.request/5 not handled: #{inspect(binding())}")
+      {:error, %K8s.Client.HTTPError{message: "request not mocked"}}
+    end
+  end
+
+  setup do
+    K8s.Client.DynamicHTTPProvider.register(self(), K8sMock)
+    :ok
+  end
+
+  defp with_status(axn, scenario, attrs \\ %{}) do
+    status = Map.merge(%{"scenario" => scenario}, attrs)
+    Bonny.Axn.update_status(axn, fn _ -> status end)
+  end
+
+  describe "init/1" do
+    test "defaults safe_mode to false" do
+      opts = MUT.init()
+      assert opts[:safe_mode] == false
+    end
+
+    test "accepts safe_mode option" do
+      opts = MUT.init(safe_mode: true)
+      assert opts[:safe_mode] == true
+    end
+
+    test "accepts field_manager and force options" do
+      opts = MUT.init(field_manager: "TestOperator", force: true)
+      assert opts[:field_manager] == "TestOperator"
+      assert opts[:force] == true
+    end
+
+    test "raises on unknown options" do
+      assert_raise ArgumentError, fn ->
+        MUT.init(safe_mode: true, unknown: "value")
+      end
+    end
+  end
+
+  describe "call/2" do
+    setup do
+      previous_level = Logger.level()
+      Logger.configure(level: :debug)
+      on_exit(fn -> Logger.configure(level: previous_level) end)
+      :ok
+    end
+
+    test "skips apply_status when action is :delete" do
+      ref = make_ref()
+
+      axn =
+        axn(:delete)
+        |> with_status("ok", %{"ref" => ResourceHelper.to_string(ref)})
+
+      result = MUT.call(axn, MUT.init(safe_mode: true))
+      assert result == axn
+      refute_receive {:status_applied, ^ref, _}
+    end
+
+    test "applies status and forwards options when safe_mode is false" do
+      ref = make_ref()
+
+      axn =
+        axn(:reconcile)
+        |> with_status("ok", %{"ref" => ResourceHelper.to_string(ref)})
+
+      result =
+        MUT.call(
+          axn,
+          MUT.init(safe_mode: false, field_manager: "MyOperator", force: true)
+        )
+
+      assert_receive {:status_applied, ^ref, query}
+      params = URI.decode_query(query || "")
+      assert params["fieldManager"] == "MyOperator"
+      assert params["force"] == "true"
+      assert result != axn
+    end
+
+    test "delegates to safe_apply_status when safe_mode is true" do
+      axn = axn(:reconcile) |> with_status("not_found")
+
+      log =
+        capture_log([level: :debug], fn ->
+          result = MUT.call(axn, MUT.init(safe_mode: true))
+          # safe_apply_status returns axn without marking status as applied
+          assert result.status == %{"scenario" => "not_found"}
+          assert result.resource["status"] == %{"scenario" => "not_found"}
+        end)
+
+      assert log =~ "Skipping status update"
+      assert log =~ "resource was deleted during reconciliation"
+    end
+
+    test "with safe_mode: false, raises on not found errors" do
+      assert_raise RuntimeError, ~r/not found/, fn ->
+        axn(:reconcile)
+        |> with_status("not_found")
+        |> MUT.call(MUT.init(safe_mode: false))
+      end
+    end
+
+    test "with safe_mode: true, re-raises non-not-found errors" do
+      assert_raise RuntimeError, ~r/some error/, fn ->
+        axn(:reconcile)
+        |> with_status("other_error")
+        |> MUT.call(MUT.init(safe_mode: true))
+      end
+    end
+  end
+end


### PR DESCRIPTION
we use bonny and experienced a idle state, due to the following error. The operator was not acting anymore until restart.

```
Task #PID<0.2668819.0> started from #PID<0.2668804.0> terminating
** (RuntimeError) {"our_xzy_operator/5a838fce-9b35-4034-adc3-bf7ac3ae6f92", "our_xzy_operator.k8s.subdomain.domain.de /v1alpha1", "Kind=XYZ, Action=:reconcile"} - Failed applying resource status. our_xzy_operator.k8s.subdomain.domain.de "5a838fce-9b35-4034-adc3-bf7ac3ae6f92" not found
(bonny 1.4.0) lib/bonny/axn.ex:363: Bonny.Axn.apply_status/2
(our_xzy_operator 1.7.7) lib/our_xzy_operator/operator.ex:1: XZYOperator.Operator.pluggable_builder_call/2
(bonny 1.4.0) lib/bonny/operator.ex:167: anonymous fn/6 in Bonny.Operator.run/4
(telemetry 1.3.0) /app/deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
(elixir 1.18.4) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
(elixir 1.18.4) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
```