### PR TITLE
fix: keep leader elector alive on Kubernetes API errors

### DIFF
--- a/lib/bonny/operator/leader_elector.ex
+++ b/lib/bonny/operator/leader_elector.ex
@@ -225,6 +225,14 @@ defmodule Bonny.Operator.LeaderElector do
             :locked
         end
 
+      {:error, %K8s.Client.APIError{} = exception} ->
+        Logger.warning(
+          "{Operator=#{inspect(operator)}} - Kubernetes API error while getting the lease. #{Exception.message(exception)}",
+          library: :bonny
+        )
+
+        :error
+
       {:ok, old_lease} ->
         if locked_by_sbdy_else?(now, old_lease, my_lease) do
           Logger.debug(

--- a/test/bonny/operator/leader_elector_test.exs
+++ b/test/bonny/operator/leader_elector_test.exs
@@ -1,0 +1,42 @@
+defmodule Bonny.Operator.LeaderElectorTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Bonny.Operator.LeaderElector
+
+  defmodule K8sMock do
+    def request(:get, _uri, _body, _headers, _opts) do
+      {:error,
+       %K8s.Client.APIError{
+         message: "etcdserver: leader changed",
+         reason: "InternalError"
+       }}
+    end
+  end
+
+  test "keeps running when the lease lookup returns a Kubernetes API error" do
+    previous_level = Logger.level()
+    Logger.configure(level: :warning)
+
+    on_exit(fn -> Logger.configure(level: previous_level) end)
+
+    conn = Bonny.K8sMock.conn(K8sMock)
+
+    log =
+      capture_log([level: :warning], fn ->
+        {:ok, pid} = LeaderElector.start_link([], __MODULE__, conn: conn)
+
+        # The state request is sent after the initial election message, ensuring
+        # that the lease lookup has completed before checking the process.
+        :sys.get_state(pid)
+        assert Process.alive?(pid)
+
+        GenServer.stop(pid)
+      end)
+
+    assert log =~ "{Operator=Bonny.Operator.LeaderElectorTest}"
+    assert log =~ "Kubernetes API error while getting the lease"
+    assert log =~ "etcdserver: leader changed"
+  end
+end


### PR DESCRIPTION
Add a fallback error branch around the existing `get_lease/2` result handling in `Bonny.Operator.LeaderElector.acquire_or_renew/2`. Log the Kubernetes API failure as a warning with the operator context and exception message, then return the same non-success outcome already consumed by `handle_info/2`, allowing that callback to schedule the next election attempt instead of crashing. Preserve the specialized `NotFound` lease-creation path, successful acquire/renew behavior, and the existing leadership-loss handling. The leader elector's `acquire_or_renew/2` function only matches a successful lease lookup or a `NotFound` API error. When Kubernetes temporarily returns another `K8s.Client.APIError`, such as AKS's `etcdserver: leader changed` response, the unmatched result raises a `CaseClauseError` and terminates the elector. The failure is intermittent, but the issue's stack trace identifies the still-current lookup branch precisely. The elector should treat this response as a failed election attempt, report it, and remain available for its normal retry cycle. A lease lookup returning a normal lease continues through the existing locked/acquire-or-renew behavior without using the new error branch; A lease lookup returning `K8s.Client.APIError` with the `etcdserver: leader changed` message logs a warning containing the failure and leaves the leader-elector process alive for retry.

Fixes #251
